### PR TITLE
Use extra_state_attributes in entity

### DIFF
--- a/config/custom_components/elero/cover.py
+++ b/config/custom_components/elero/cover.py
@@ -233,7 +233,7 @@ class EleroCover(CoverEntity):
         return self._state
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return device specific state attributes."""
         data = {}
 


### PR DESCRIPTION
Switch from device_state_attributes to extra_state_attributes in the CoverEntity to fix warnings in the log.