### PR TITLE
Fix deprecated constant usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,8 @@ Feature branches with lots of small commits (especially titled "oops", "fix typo
 ---
 
 # Version
+* 3.3.1 - March 11, 2023 [Fix Deprecated Constant Usage](https://github.com/W00D00/home-assistant-elero/pull/45)
+* 3.3 - May 12, 2023 [Using remote transmitter with ser2net](https://github.com/W00D00/home-assistant-elero/pull/40) & [Fix execution on HA2023.5.](https://github.com/W00D00/home-assistant-elero/pull/43)
 * 3.2.2 - November 17, 2022 [Introduce the unique ID](https://github.com/W00D00/home-assistant-elero/pull/38)
 * 3.2.1 - March 10, 2022 [Fix TypeError on HA Shutdowm](https://github.com/W00D00/home-assistant-elero/pull/36)
 * 3.2.0 - March 10, 2022 [Added support for HACS](https://github.com/W00D00/home-assistant-elero/issues/23)

--- a/custom_components/elero/__init__.py
+++ b/custom_components/elero/__init__.py
@@ -1,6 +1,6 @@
 """Support for Elero electrical drives."""
 
-__version__ = "3.2.2"
+__version__ = "3.3.1"
 
 import logging
 

--- a/custom_components/elero/cover.py
+++ b/custom_components/elero/cover.py
@@ -7,12 +7,8 @@ import logging
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant.components.cover import (ATTR_POSITION, ATTR_TILT_POSITION,
-                                            SUPPORT_CLOSE, SUPPORT_CLOSE_TILT,
-                                            SUPPORT_OPEN, SUPPORT_OPEN_TILT,
-                                            SUPPORT_SET_POSITION,
-                                            SUPPORT_SET_TILT_POSITION,
-                                            SUPPORT_STOP, SUPPORT_STOP_TILT,
-                                            CoverEntity)
+                                            CoverEntity,
+                                            CoverEntityFeature)
 from homeassistant.components.light import PLATFORM_SCHEMA
 from homeassistant.const import (CONF_COVERS, CONF_DEVICE_CLASS, CONF_NAME,
                                  STATE_CLOSED, STATE_CLOSING, STATE_OPEN,
@@ -72,14 +68,14 @@ STATE_UNDEFINED = "undefined"
 
 # Supported features.
 SUPPORTED_FEATURES = {
-    "close_tilt": SUPPORT_CLOSE_TILT,
-    "down": SUPPORT_CLOSE,
-    "open_tilt": SUPPORT_OPEN_TILT,
-    "set_position": SUPPORT_SET_POSITION,
-    "set_tilt_position": SUPPORT_SET_TILT_POSITION,
-    "stop_tilt": SUPPORT_STOP_TILT,
-    "stop": SUPPORT_STOP,
-    "up": SUPPORT_OPEN,
+    "close_tilt": CoverEntityFeature.CLOSE_TILT,
+    "down": CoverEntityFeature.CLOSE,
+    "open_tilt": CoverEntityFeature.OPEN_TILT,
+    "set_position": CoverEntityFeature.SET_POSITION,
+    "set_tilt_position": CoverEntityFeature.SET_TILT_POSITION,
+    "stop_tilt": CoverEntityFeature.STOP_TILT,
+    "stop": CoverEntityFeature.STOP,
+    "up": CoverEntityFeature.OPEN,
 }
 
 ELERO_COVER_DEVICE_CLASSES_SCHEMA = vol.All(

--- a/custom_components/elero/manifest.json
+++ b/custom_components/elero/manifest.json
@@ -1,6 +1,6 @@
 {
     "domain": "elero",
-    "version": "3.2.1",
+    "version": "3.3.1",
     "name": "Elero",
     "documentation": "https://github.com/W00D00/home-assistant-elero",
     "dependencies": [],


### PR DESCRIPTION
Fix deprecated constant `SUPPORT_*` usage as per [HA dev blog](https://developers.home-assistant.io/blog/2022/04/02/support-constants-deprecation/).